### PR TITLE
Removed polypy ssl option.

### DIFF
--- a/polypy.py
+++ b/polypy.py
@@ -16,7 +16,6 @@ Commands:
   sip        Manage sip.conf
   site       Manage site files
   version    Show the version of this package
-  ssl        Configure SSL for a phone.
   deploy     Deploy files rendered to tftproot
  
 See polypy help <command> for more information with a specific command.
@@ -70,9 +69,9 @@ if __name__ == '__main__':
         from poly_py_tools import sip_manager
         docopt(sip_manager.__doc__, argv=argv)
 
-    if args['<command>'] == 'ssl':
-        from poly_py_tools import ssl_manager
-        docopt(ssl_manager.__doc__, argv=argv)
+    # if args['<command>'] == 'ssl':
+    #     from poly_py_tools import ssl_manager
+    #     docopt(ssl_manager.__doc__, argv=argv)
 
     if args['<command>'] == 'site':
         from poly_py_tools import polypy_site


### PR DESCRIPTION
 This is already done by another utility, and may be merged in the future. Maybe.